### PR TITLE
Fix dependencies.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "CSSI-CP2K"]
+	path = CSSI-CP2K
+	url = https://github.com/ramanishsingh/CSSI-CP2K

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # cp2k-nvt
-make a mosdef36 env:<br /><br />
-conda create -n mosdef36 python=3.6<br />
-conda activate mosdef36<br />
-conda install -c mosdef -c conda-forge -c omnia mbuild foyer<br />
 
-You would also need to install signac  (signac.io) in the env
+Make a `mosdef36` conda environment:
+
+```bash
+conda create -n mosdef36 -c mosdef -c conda-forge -c omnia python=3.6 mbuild foyer signac signac-flow
+conda activate mosdef36
+```


### PR DESCRIPTION
This PR fixes the broken git submodule for CSSI-CP2K (the `.gitmodules` file was missing. The repo may have worked fine on your machine because you had that file locally or your git index was already configured, @ramanishsingh. However, it was not configured properly for other people who clone the repo.

I also updated the installation instructions in the README. `signac` and `signac-flow` can be installed via the conda-forge channel.